### PR TITLE
Improve tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -3,36 +3,34 @@
 var unvowel = require('./');
 var assert  = require('assert');
 
-var WHITE_SPACE = /\s+/g;
-var VOWELS      = /[aeiou]+/gi;
+var hasWhitespace = function (str) {
+  return /\s/.test(str);
+}
 
 describe('unvowel#parse', function() {
   it('should remove vowels from a string', function(){
     var str = 'aeiou';
-    var unvoweled = unvowel.parse(str).split(/\s+/g);
-
-    assert.equal(unvoweled.indexOf(VOWELS), -1);
+    assert.equal(unvowel.parse(str), '');
   });
 
   it('should not join strings after unvoweling by default', function() {
     var str = 'goofy yuki';
     var unvoweled = unvowel.parse(str);
 
-    assert.notEqual(unvoweled.search(WHITE_SPACE), -1);
+    assert(hasWhitespace(unvoweled));
   });
 
   it('should join strings after unvoweling with join option set to true', function() {
     var str = 'goofy yuki';
     var unvoweled = unvowel.parse(str, true);
 
-    assert.equal(unvoweled.search(WHITE_SPACE), -1);
+    assert(!hasWhitespace(unvoweled));
   });
 
   it('should not join strings after unvoweling with join option set to false', function() {
     var str = 'goofy yuki';
     var unvoweled = unvowel.parse(str, false);
 
-    assert.notEqual(unvoweled.search(WHITE_SPACE), -1);
+    assert(hasWhitespace(unvoweled));
   });
-
 });


### PR DESCRIPTION
- simplify code
- actually compare the result of `unvowel.parse` directly with the expected result, this way more bugs become visible.
